### PR TITLE
Fix null deref when fetching connection options

### DIFF
--- a/internal/provider/ccloud/ccloud_client.go
+++ b/internal/provider/ccloud/ccloud_client.go
@@ -253,7 +253,8 @@ func (c *CcloudClient) getConnectionOptions(ctx context.Context, clusterId strin
 		return nil, err
 	}
 
-	if processCloudResponse(resp, nil) != nil {
+	err = processCloudResponse(resp, nil)
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
There are a few issues connecting to dedicated clusters, but the error is not handled correctly, fix that first.

The bug here is that err is not updated, and the err returned is nil, causing the calling code to think there is no err and deref the null struct.

Might fix #7 