### PR TITLE
revoke all permissions on role destroy

### DIFF
--- a/internal/provider/resources/migration_resource.go
+++ b/internal/provider/resources/migration_resource.go
@@ -294,18 +294,7 @@ func (r *MigrationResource) Delete(ctx context.Context, req resource.DeleteReque
 		}(sourceDriver)
 
 		migrator, err := migrate.NewWithInstance(data.MigrationsUrl.ValueString(), sourceDriver, data.Database.ValueString(), driver)
-		if err != nil {
-			return nil, err
-		}
-		if data.DestroyMode.ValueString() == "drop" {
-			_, err = db.Exec("DROP DATABASE IF EXISTS " + pgx.Identifier{data.Database.ValueString()}.Sanitize())
-			if err != nil {
-				return nil, err
-			}
-			_, err = db.Exec("CREATE DATABASE IF NOT EXISTS " + pgx.Identifier{data.Database.ValueString()}.Sanitize())
-		} else {
-			err = migrator.Down()
-		}
+		err = migrator.Down()
 
 		return nil, err
 	})

--- a/internal/provider/resources/sql_role_resource.go
+++ b/internal/provider/resources/sql_role_resource.go
@@ -147,7 +147,13 @@ func (r *SqlRoleResource) Delete(ctx context.Context, req resource.DeleteRequest
 	}
 
 	_, err := ccloud.SqlConWithTempUser(ctx, r.client, data.ClusterId.ValueString(), "defaultdb", func(db *pgx.ConnPool) (*interface{}, error) {
-		_, err := db.Exec(fmt.Sprintf("DROP ROLE %s", pgx.Identifier{data.RoleName.ValueString()}.Sanitize()))
+		_, err := db.Exec(fmt.Sprintf("REVOKE ALL ON * FROM %s", pgx.Identifier{data.RoleName.ValueString()}.Sanitize()))
+
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = db.Exec(fmt.Sprintf("DROP ROLE %s", pgx.Identifier{data.RoleName.ValueString()}.Sanitize()))
 		return nil, err
 	})
 

--- a/internal/provider/resources/sql_user_resource.go
+++ b/internal/provider/resources/sql_user_resource.go
@@ -177,7 +177,13 @@ func (r *SqlUserResource) Delete(ctx context.Context, req resource.DeleteRequest
 	}
 
 	_, err := ccloud.SqlConWithTempUser(ctx, r.client, data.ClusterId.ValueString(), "defaultdb", func(db *pgx.ConnPool) (*interface{}, error) {
-		_, err := db.Exec(fmt.Sprintf("DROP USER %s", pgx.Identifier{data.Username.ValueString()}.Sanitize()))
+		_, err := db.Exec(fmt.Sprintf("REVOKE ALL ON * FROM %s", pgx.Identifier{data.Username.ValueString()}.Sanitize()))
+
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = db.Exec(fmt.Sprintf("DROP USER %s", pgx.Identifier{data.Username.ValueString()}.Sanitize()))
 		return nil, err
 	})
 


### PR DESCRIPTION
Currently, role and user destruction will fail if there are still associated permission grants. This PR revokes all permissions and grants before destruction, fixing the issue