### PR TITLE
fix: create changefeed no longer always updates cursor

### DIFF
--- a/internal/provider/resources/changefeed_resource.go
+++ b/internal/provider/resources/changefeed_resource.go
@@ -600,13 +600,13 @@ func (r *ChangefeedResource) Create(ctx context.Context, req resource.CreateRequ
 			resp.Diagnostics.AddError("Unable to update cursor job ID", err.Error())
 			_, err := ccloud.SqlConWithTempUser(ctx, r.client, data.ClusterId.ValueString(), "defaultdb", func(db *pgx.ConnPool) (*interface{}, error) {
 				_, err := db.Exec(fmt.Sprintf("CANCEL JOB %d", data.JobId.ValueInt64()))
-	
+
 				if err != nil {
 					return nil, err
 				}
-	
+
 				err = waitForJobStatus(db, data.JobId.ValueInt64(), "canceled")
-	
+
 				return nil, err
 			})
 			if err != nil {


### PR DESCRIPTION
Creating a changefeed resource attempts to update a persistent cursor even though one is not specified in the create property, which throws an error when looking up the `persistent_cursor` table without a persistent_cursor resource ensuring the creation of said table.